### PR TITLE
Filtrado de provincias en Inmovilla: cache y manejo de importaciones

### DIFF
--- a/includes/class-helper-api.php
+++ b/includes/class-helper-api.php
@@ -1470,22 +1470,28 @@ class API {
 	 * @param bool $only_with_properties Only provinces with properties.
 	 * @return array
 	 */
-	public static function get_inmovilla_provincias( $only_with_properties = true ) {
-		$result = get_transient( 'ccrmre_query_inmovilla_provincias' );
+	public static function get_inmovilla_provincias( $only_with_properties = true, $force_refresh = false ) {
+		$transient_key = 'ccrmre_query_inmovilla_provincias';
+
+		if ( $force_refresh ) {
+			delete_transient( $transient_key );
+		}
+
+		$result = get_transient( $transient_key );
 		if ( false === $result || empty( $result['data'] ) || 'ok' !== $result['status'] ) {
 			$tipo   = $only_with_properties ? 'provinciasofertas' : 'provincias';
 			$result = self::request_inmovilla( $tipo, 1, 100 );
 
 			if ( 'ok' === $result['status'] && isset( $result['data'][ $tipo ] ) ) {
-				// Remove metadata row.
 				$provincias = $result['data'][ $tipo ];
 				unset( $provincias[0] );
-				return array(
+				$result = array(
 					'status' => 'ok',
 					'data'   => array_values( $provincias ),
 				);
 			}
-			set_transient( 'ccrmre_query_inmovilla_provincias', $result, DAY_IN_SECONDS );
+			// No TTL: provinces don't change. Refresh only via explicit button.
+			set_transient( $transient_key, $result, 0 );
 		}
 		return $result;
 	}

--- a/includes/class-helper-api.php
+++ b/includes/class-helper-api.php
@@ -1468,6 +1468,7 @@ class API {
 	 * Get provinces from Inmovilla
 	 *
 	 * @param bool $only_with_properties Only provinces with properties.
+	 * @param bool $force_refresh Force a fresh API call ignoring cached transient.
 	 * @return array
 	 */
 	public static function get_inmovilla_provincias( $only_with_properties = true, $force_refresh = false ) {

--- a/includes/class-helper-sync.php
+++ b/includes/class-helper-sync.php
@@ -550,8 +550,8 @@ class SYNC {
 		$settings  = get_option( 'ccrmre_settings' );
 		$post_type = isset( $settings['post_type'] ) ? $settings['post_type'] : CCRMRE_POST_TYPE;
 
-		// Get all property IDs from API.
-		$api_result = API::get_all_property_ids( $crm_type );
+		// Get all property IDs from API (use cached result if available).
+		$api_result = API::get_all_property_ids( $crm_type, true );
 		if ( 'error' === $api_result['status'] ) {
 			return array(
 				'status'  => 'error',

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -187,7 +187,10 @@ class Import {
 					);
 				}
 
-				$error_message  = $result_api['data'] ?? __( 'Error connecting with API. Please check your API connection.', 'connect-crm-realstate' );
+				$error_message  = ! empty( $result_api['message'] ) ? $result_api['message'] : __( 'Error connecting with API. Please check your API connection.', 'connect-crm-realstate' );
+				if ( str_contains( $error_message, 'error: 0' ) ) {
+					$error_message = __( 'Inmovilla API returned error code 0. This usually means the server IP is not registered in Inmovilla or the API is temporarily unavailable.', 'connect-crm-realstate' );
+				}
 				$error_message .= '. ' . __( 'If your credentials are correct, wait a few minutes and try again.', 'connect-crm-realstate' );
 
 				$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $error_message . '<br/>';
@@ -373,6 +376,15 @@ class Import {
 		if ( 'updated' === $mode ) {
 			$fake_properties = array();
 			foreach ( $data as $id => $meta ) {
+				$minimal = SYNC::build_minimal_item( $id, $crm );
+				if ( isset( $meta['state_code'] ) && '' !== $meta['state_code'] ) {
+					$minimal['state_code'] = $meta['state_code'];
+				}
+				$minimal['status'] = isset( $meta['status'] ) ? $meta['status'] : true;
+				if ( ! apply_filters( 'ccrmre_should_import_property', true, $minimal ) ) {
+					continue;
+				}
+
 				if ( 'anaconda' === $crm ) {
 					$fake_properties[] = array(
 						'id'         => $id,
@@ -407,9 +419,11 @@ class Import {
 
 		$items = array();
 		foreach ( $ids as $id ) {
-			$minimal = SYNC::build_minimal_item( $id, $crm );
-			$status  = isset( $data[ $id ]['status'] ) ? $data[ $id ]['status'] : true;
-			$items[] = array_merge( $minimal, array( 'status' => $status ) );
+			$minimal    = SYNC::build_minimal_item( $id, $crm );
+			$status     = isset( $data[ $id ]['status'] ) ? $data[ $id ]['status'] : true;
+			$state_code = isset( $data[ $id ]['state_code'] ) ? $data[ $id ]['state_code'] : '';
+			$extra      = '' !== $state_code ? array( 'state_code' => $state_code ) : array();
+			$items[]    = array_merge( $minimal, array( 'status' => $status ), $extra );
 		}
 
 		return $items;

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -435,7 +435,7 @@ class Import {
 			$state_code = isset( $data[ $id ]['state_code'] ) ? $data[ $id ]['state_code'] : '';
 			$extra      = '' !== $state_code ? array( 'state_code' => $state_code ) : array();
 			$item       = array_merge( $minimal, array( 'status' => $status ), $extra );
-			
+
 			// In "all mode" check if we must import or not and clean list.
 			if ( ! apply_filters( 'ccrmre_should_import_property', true, $item ) ) {
 				continue;

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -423,7 +423,13 @@ class Import {
 			$status     = isset( $data[ $id ]['status'] ) ? $data[ $id ]['status'] : true;
 			$state_code = isset( $data[ $id ]['state_code'] ) ? $data[ $id ]['state_code'] : '';
 			$extra      = '' !== $state_code ? array( 'state_code' => $state_code ) : array();
-			$items[]    = array_merge( $minimal, array( 'status' => $status ), $extra );
+			$item       = array_merge( $minimal, array( 'status' => $status ), $extra );
+			
+			// In "all mode" check if we must import or not and clean list.
+			if ( ! apply_filters( 'ccrmre_should_import_property', true, $item ) ) {
+				continue;
+			}
+			$items[] = $item;
 		}
 
 		return $items;

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -187,11 +187,22 @@ class Import {
 					);
 				}
 
-				$error_message  = ! empty( $result_api['message'] ) ? $result_api['message'] : __( 'Error connecting with API. Please check your API connection.', 'connect-crm-realstate' );
+				$error_message = ! empty( $result_api['message'] ) ? $result_api['message'] : __( 'Error connecting with API. Please check your API connection.', 'connect-crm-realstate' );
 				if ( str_contains( $error_message, 'error: 0' ) ) {
-					$error_message = __( 'Inmovilla API returned error code 0. This usually means the server IP is not registered in Inmovilla or the API is temporarily unavailable.', 'connect-crm-realstate' );
+					$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:orange;">' . __( 'Inmovilla API temporarily unavailable (error 0). Waiting before retry...', 'connect-crm-realstate' ) . '</strong><br/>';
+
+					wp_send_json_success(
+						array(
+							'loop'         => $loop,
+							'message'      => $progress_msg,
+							'pagination'   => $pagination,
+							'totalprop'    => $totalprop,
+							'finish'       => false,
+							'rate_limit'   => true,
+							'wait_seconds' => 60,
+						)
+					);
 				}
-				$error_message .= '. ' . __( 'If your credentials are correct, wait a few minutes and try again.', 'connect-crm-realstate' );
 
 				$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $error_message . '<br/>';
 

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -188,7 +188,7 @@ class Import {
 				}
 
 				$error_message = ! empty( $result_api['message'] ) ? $result_api['message'] : __( 'Error connecting with API. Please check your API connection.', 'connect-crm-realstate' );
-				if ( str_contains( $error_message, 'error: 0' ) ) {
+				if ( false !== strpos( $error_message, 'error: 0' ) ) {
 					$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:orange;">' . __( 'Inmovilla API temporarily unavailable (error 0). Waiting before retry...', 'connect-crm-realstate' ) . '</strong><br/>';
 
 					wp_send_json_success(


### PR DESCRIPTION
- Cache indefinido de provincias: Las provincias se cachean sin expiración y pueden actualizarse manualmente cuando sea necesario.
- Filtrado consistente: El filtro por provincia se aplica en todos los modos de importación (manual, actualización y sincronización automática).
- Manejo de errores: Se añaden reintentos cuando Inmovilla devuelve el error 0, mejorando la robustez de la integración.