### PR TITLE
Detect Inmovilla IP whitelist errors and add mailto support link

### DIFF
--- a/includes/class-helper-api.php
+++ b/includes/class-helper-api.php
@@ -214,7 +214,7 @@ class API {
 		$url = 'https://apiweb.inmovilla.com/apiweb/apiweb.php';
 
 		return self::execute_with_retry(
-			function () use ( $url, $args ) {
+			function () use ( $url, $args, $numagencia, $hostname ) {
 				$response = wp_remote_post( $url, $args );
 
 				self::save_inmovilla_cookies( $response );
@@ -248,21 +248,9 @@ class API {
 
 				if ( json_last_error() !== JSON_ERROR_NONE ) {
 					// Detect Inmovilla IP registration error (plain-text response, not JSON).
-					if ( is_string( $body ) && false !== stripos( $body, 'NECESITAMOS RECIBIR LA IP' ) ) {
-						$server_ip = isset( $_SERVER['SERVER_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_ADDR'] ) ) : '';
-						if ( empty( $server_ip ) ) {
-							$server_ip = gethostbyname( gethostname() );
-						}
-						return array(
-							'status'     => 'error',
-							'message'    => sprintf(
-								/* translators: %s: Server IP address */
-								__( 'Inmovilla API requires IP registration. Please provide your server IP (%s) to Inmovilla support so they can whitelist it.', 'connect-crm-realstate' ),
-								$server_ip
-							),
-							'data'       => array(),
-							'error_type' => 'ip_not_registered',
-						);
+					$ip_error = self::detect_ip_whitelist_error( $body, $numagencia, $hostname );
+					if ( null !== $ip_error ) {
+						return $ip_error;
 					}
 					$message  = __( 'Invalid JSON response from Inmovilla API', 'connect-crm-realstate' );
 					$message .= is_string( $body ) ? ' - ' . $body : '';
@@ -280,6 +268,72 @@ class API {
 				);
 			},
 			'Inmovilla API Web'
+		);
+	}
+
+	/**
+	 * Detect Inmovilla IP whitelist error and build an actionable response
+	 *
+	 * Inmovilla APIWEB returns a plain-text die() body (not JSON) when the
+	 * server's outbound IP has not been whitelisted. It has been observed
+	 * using more than one wording for this, so several patterns are checked.
+	 *
+	 * @param mixed  $body Raw response body.
+	 * @param string $numagencia Agency number configured in plugin settings.
+	 * @param string $hostname Site hostname.
+	 * @return array|null Error response array (status/message/error_type/mailto), or null if body doesn't match.
+	 */
+	private static function detect_ip_whitelist_error( $body, $numagencia, $hostname ) {
+		if ( ! is_string( $body ) ) {
+			return null;
+		}
+
+		$ip_error_patterns = array( 'NECESITAMOS RECIBIR LA IP', 'IP NO VALIDADA', 'IP_RECIVED' );
+		$matched           = false;
+		foreach ( $ip_error_patterns as $pattern ) {
+			if ( false !== stripos( $body, $pattern ) ) {
+				$matched = true;
+				break;
+			}
+		}
+
+		if ( ! $matched ) {
+			return null;
+		}
+
+		// Prefer the IP Inmovilla reports having received: it reflects what
+		// their firewall actually saw, which can differ from the server's
+		// local IP when there's a proxy/CDN/load balancer in front.
+		$ip = '';
+		if ( preg_match( '/IP_RECIVED:\s*([0-9.]+)/i', $body, $matches ) ) {
+			$ip = $matches[1];
+		} else {
+			$ip = isset( $_SERVER['SERVER_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_ADDR'] ) ) : '';
+			if ( empty( $ip ) ) {
+				$ip = gethostbyname( gethostname() );
+			}
+		}
+
+		$mailto_body = sprintf(
+			"Hello,\n\nPlease whitelist the following IP address so our WordPress site can connect to the Inmovilla API:\n\nIP: %s\nAgency number: %s\nWebsite: %s\n\nThank you.",
+			$ip,
+			$numagencia,
+			$hostname
+		);
+		$mailto      = 'mailto:soporte@inmovilla.com'
+			. '?subject=' . rawurlencode( sprintf( 'IP whitelist request - Agency %s', $numagencia ) )
+			. '&body=' . rawurlencode( $mailto_body );
+
+		return array(
+			'status'     => 'error',
+			'message'    => sprintf(
+				/* translators: %s: Server IP address */
+				__( 'Inmovilla API requires IP registration. Please ask Inmovilla support to whitelist your server IP (%s).', 'connect-crm-realstate' ),
+				$ip
+			),
+			'data'       => array(),
+			'error_type' => 'ip_not_registered',
+			'mailto'     => $mailto,
 		);
 	}
 

--- a/includes/class-iip-import.php
+++ b/includes/class-iip-import.php
@@ -204,7 +204,7 @@ class Import {
 					);
 				}
 
-				$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $error_message . '<br/>';
+				$progress_msg .= '[' . date_i18n( 'H:i:s' ) . '] <strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $error_message . self::format_ip_whitelist_notice( $result_api ) . '<br/>';
 
 				wp_send_json_error(
 					array(
@@ -292,7 +292,7 @@ class Import {
 					}
 
 					$progress_msg .= $line_prefix . esc_html( $id_display ) . ' ERR - ';
-					$progress_msg .= '<strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $result_get_property['message'] . '<br/>';
+					$progress_msg .= '<strong style="color:red;">' . __( 'API ERROR:', 'connect-crm-realstate' ) . '</strong> ' . $result_get_property['message'] . self::format_ip_whitelist_notice( $result_get_property ) . '<br/>';
 					wp_send_json_success(
 						array(
 							'loop'       => $loop + 1,
@@ -610,5 +610,21 @@ class Import {
 		$label  = __( 'Property', 'connect-crm-realstate' );
 		$suffix = self::format_title_city_suffix_static( $title, $city );
 		return '[' . $time . '] ' . (int) $index . ' - ' . $label . ' ' . (string) $ref . ' ' . $action . $suffix;
+	}
+
+	/**
+	 * Builds the "ask Inmovilla to whitelist this IP" link for the sync log.
+	 *
+	 * @param array $result API result array, possibly containing 'error_type' and 'mailto'.
+	 * @return string HTML snippet with a mailto link, or empty string when not applicable.
+	 */
+	private static function format_ip_whitelist_notice( $result ) {
+		if ( ! isset( $result['error_type'] ) || 'ip_not_registered' !== $result['error_type'] || empty( $result['mailto'] ) ) {
+			return '';
+		}
+
+		return ' <a href="' . esc_url( $result['mailto'] ) . '" target="_blank" rel="noopener noreferrer">'
+			. esc_html__( 'Request IP whitelist from Inmovilla support', 'connect-crm-realstate' )
+			. '</a>';
 	}
 }

--- a/tests/Unit/HelperApiTest.php
+++ b/tests/Unit/HelperApiTest.php
@@ -34,6 +34,15 @@ class HelperAPITest extends WP_UnitTestCase {
 	private $mock_api_error = false;
 
 	/**
+	 * When set, the APIWEB mock returns this raw string body (HTTP 200) instead
+	 * of the file-based JSON mock. Used to simulate Inmovilla's plain-text
+	 * die() responses (e.g. IP whitelist errors).
+	 *
+	 * @var string|null
+	 */
+	private $mock_apiweb_body = null;
+
+	/**
 	 * Set up test environment.
 	 */
 	public function setUp(): void {
@@ -41,6 +50,7 @@ class HelperAPITest extends WP_UnitTestCase {
 
 		$this->mock_api_properties = null;
 		$this->mock_api_error      = false;
+		$this->mock_apiweb_body    = null;
 		$this->cleanup_properties();
 
 		// Avoid sleep() in execute_with_retry when mock returns error (test_propagates_api_http_error, etc.).
@@ -93,6 +103,12 @@ class HelperAPITest extends WP_UnitTestCase {
 				return array(
 					'body'     => '',
 					'response' => array( 'code' => 500, 'message' => 'Internal Server Error' ),
+				);
+			}
+			if ( null !== $this->mock_apiweb_body ) {
+				return array(
+					'body'     => $this->mock_apiweb_body,
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
 				);
 			}
 			$tipo = 'paginacion';
@@ -381,6 +397,56 @@ class HelperAPITest extends WP_UnitTestCase {
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertArrayHasKey( 'message', $result );
 		$this->assertEmpty( $result['data'] );
+	}
+
+	/**
+	 * Inmovilla API (APIWEB): "NECESITAMOS RECIBIR LA IP" die() body is detected
+	 * as an IP whitelist error and produces a mailto link.
+	 */
+	public function test_inmovilla_api_detects_ip_whitelist_error_necesitamos() {
+		$this->mock_apiweb_body = 'die("NECESITAMOS RECIBIR LA IP");';
+		update_option(
+			'ccrmre_settings',
+			array(
+				'type'        => 'inmovilla',
+				'numagencia'  => '6533',
+				'apipassword' => 'test',
+				'post_type'   => 'property',
+			)
+		);
+
+		$result = API::request_inmovilla( 'paginacion', 1, 10 );
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'ip_not_registered', $result['error_type'] );
+		$this->assertArrayHasKey( 'mailto', $result );
+		$this->assertStringContainsString( 'mailto:soporte@inmovilla.com', $result['mailto'] );
+	}
+
+	/**
+	 * Inmovilla API (APIWEB): "xIP NO VALIDADA - IP_RECIVED: ..." die() body is
+	 * also detected as an IP whitelist error, extracting the reported IP.
+	 */
+	public function test_inmovilla_api_detects_ip_whitelist_error_ip_recived() {
+		$this->mock_apiweb_body = 'die("xIP NO VALIDADA - IP_RECIVED: 217.160.134.44 --- 12066_244_ext");';
+		update_option(
+			'ccrmre_settings',
+			array(
+				'type'        => 'inmovilla',
+				'numagencia'  => '6533',
+				'apipassword' => 'test',
+				'post_type'   => 'property',
+			)
+		);
+
+		$result = API::request_inmovilla( 'paginacion', 1, 10 );
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'ip_not_registered', $result['error_type'] );
+		$this->assertStringContainsString( '217.160.134.44', $result['message'] );
+		$this->assertArrayHasKey( 'mailto', $result );
+		$this->assertStringContainsString( 'mailto:soporte@inmovilla.com', $result['mailto'] );
+		$this->assertStringContainsString( rawurlencode( '217.160.134.44' ), $result['mailto'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #35.

Inmovilla APIWEB rejects requests from a non-whitelisted IP with a plain-text `die()` body instead of JSON, and it has been observed using more than one wording for this. Only `NECESITAMOS RECIBIR LA IP` was detected before (#14), so a different variant — `xIP NO VALIDADA - IP_RECIVED: 217.160.134.44 --- 12066_244_ext` — fell through to the generic branch and leaked the raw `die()` string into the admin sync log with no guidance for the client:

```
[17:20:44] ERROR DE API: Respuesta JSON no válida de la API de Inmovilla - die("xIP NO VALIDADA - IP_RECIVED: 217.160.134.44 --- 12066_244_ext");
```

- `includes/class-helper-api.php`: extracted the IP-whitelist detection from `request_inmovilla()` into `detect_ip_whitelist_error()`, which now matches both known `die()` wordings. When the body contains `IP_RECIVED: <ip>`, that reported IP is used (it reflects what Inmovilla's firewall actually saw, which can differ from the server's own IP behind a proxy/CDN/load balancer — relevant to #32). The error response now also carries a ready-to-send `mailto:soporte@inmovilla.com` link with the IP, agency number, and site domain pre-filled.
- `includes/class-iip-import.php`: added `format_ip_whitelist_notice()` and wired it into both places where "API ERROR:" is rendered in the sync progress log, so the client sees a link to request the whitelist instead of just the raw error text.
- `tests/Unit/HelperApiTest.php`: added a way to mock the Inmovilla APIWEB raw body and two tests covering both `die()` wordings, asserting `error_type = ip_not_registered` and that the `mailto` link is present and contains the detected IP.

## Test plan

- [x] `php -l` on all changed files
- [x] New unit tests added for both IP-whitelist `die()` wordings (`NECESITAMOS RECIBIR LA IP` and `xIP NO VALIDADA - IP_RECIVED: ...`)
- [ ] Could not run the PHPUnit suite in this sandbox (no MySQL/wp-phpunit test environment available, and `composer install` timed out with no network access) — please run CI on this PR
- [ ] Manually trigger a sync against a non-whitelisted agency (or otherwise reproduce the `die()` body) to confirm the mailto link renders correctly in the admin sync log


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGGZhAFKuUzuZnq2GZzk95)_