### PR TITLE
Add configurable Inmovilla IA and IB IP settings

### DIFF
--- a/connect-crm-realstate.php
+++ b/connect-crm-realstate.php
@@ -5,7 +5,7 @@
  * Description: Connect Properties from Inmovilla/Anaconda to a Custom Post Type.
  * Author: closetechnology
  * Author URI: https://close.technology/
- * Version: 1.2.5-beta.13
+ * Version: 1.2.5-rc.1
  *
  * @package WordPress
  * Text Domain: connect-crm-realstate
@@ -19,7 +19,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'CCRMRE_VERSION', '1.2.5-beta.13' );
+define( 'CCRMRE_VERSION', '1.2.5-rc.1' );
 define( 'CCRMRE_PLUGIN', __FILE__ );
 define( 'CCRMRE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CCRMRE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/connect-crm-realstate.php
+++ b/connect-crm-realstate.php
@@ -5,7 +5,7 @@
  * Description: Connect Properties from Inmovilla/Anaconda to a Custom Post Type.
  * Author: closetechnology
  * Author URI: https://close.technology/
- * Version: 1.2.5-beta.12
+ * Version: 1.2.5-beta.13
  *
  * @package WordPress
  * Text Domain: connect-crm-realstate
@@ -19,7 +19,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'CCRMRE_VERSION', '1.2.5-beta.12' );
+define( 'CCRMRE_VERSION', '1.2.5-beta.13' );
 define( 'CCRMRE_PLUGIN', __FILE__ );
 define( 'CCRMRE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CCRMRE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/assets/iip-client-ip.js
+++ b/includes/assets/iip-client-ip.js
@@ -1,0 +1,55 @@
+/**
+ * Detect the administrator's public IP address when a local proxy hides it
+ * from WordPress, then save it as the Inmovilla APIWEB IA parameter.
+ *
+ * @package Connect_CRM_RealState
+ */
+
+(function() {
+	'use strict';
+
+	if (typeof window.ccrmreClientIp === 'undefined' || typeof window.fetch !== 'function') {
+		return;
+	}
+
+	fetch('https://api.ipify.org?format=json', { credentials: 'omit' })
+		.then(function(response) {
+			if (!response.ok) {
+				throw new Error('Unable to detect client IP.');
+			}
+
+			return response.json();
+		})
+		.then(function(data) {
+			if (!data.ip) {
+				return;
+			}
+
+			return fetch(window.ccrmreClientIp.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+				},
+				body: new URLSearchParams({
+					action: 'ccrmre_store_inmovilla_client_ip',
+					nonce: window.ccrmreClientIp.nonce,
+					ip: data.ip
+				})
+			});
+		})
+		.then(function(response) {
+			if (!response) {
+				return;
+			}
+
+			return response.json();
+		})
+		.then(function(result) {
+			if (result && result.success && result.data.updated && window.ccrmreClientIp.reloadPage) {
+				window.location.reload();
+			}
+		})
+		.catch(function() {
+			// Leave IA empty when the external lookup is unavailable.
+		});
+})();

--- a/includes/assets/iip-settings.js
+++ b/includes/assets/iip-settings.js
@@ -31,12 +31,21 @@
 			});
 		}
 
+		function toggleIbOverride() {
+			$('#ccrmre_inmovilla_ib').prop('disabled', ! $('#ccrmre_inmovilla_ib_override').is(':checked'));
+		}
+
 		// Initial state on page load.
 		toggleInmovillaFields();
+		toggleIbOverride();
 
 		// Toggle on CRM type change.
 		$('#type').on('change', function() {
 			toggleInmovillaFields();
+		});
+
+		$('#ccrmre_inmovilla_ib_override').on('change', function() {
+			toggleIbOverride();
 		});
 	});
 

--- a/includes/assets/iip-settings.js
+++ b/includes/assets/iip-settings.js
@@ -16,7 +16,9 @@
 		function toggleInmovillaFields() {
 			var selectedType = $('#type').val();
 			var inmovillaFields = [
-				'#numagencia'
+				'#numagencia',
+				'#ccrmre_inmovilla_ia',
+				'#ccrmre_inmovilla_ib'
 			];
 
 			inmovillaFields.forEach(function(fieldId) {

--- a/includes/class-helper-api.php
+++ b/includes/class-helper-api.php
@@ -181,12 +181,22 @@ class API {
 		$texto = rawurlencode( $texto );
 
 		// Build POST body with IP tracking for API security.
-		$ia        = self::get_configured_inmovilla_ip( $settings, 'ia', self::get_inmovilla_client_ip() );
-		$server_ip = self::get_configured_inmovilla_ip( $settings, 'ib', self::get_inmovilla_server_ip() );
-		$body      = 'param=' . $texto;
-		$body     .= '&json=1'; // Request JSON response.
-		$body     .= '&ia=' . rawurlencode( $ia );
-		$body     .= '&ib=' . rawurlencode( $server_ip );
+		$ia = self::get_configured_inmovilla_ip( $settings, 'ia' );
+		if ( '' === $ia ) {
+			$ia = self::get_inmovilla_client_ip();
+		}
+		if ( '' === $ia ) {
+			$ia = self::get_inmovilla_server_ip();
+		}
+
+		$server_ip = self::get_configured_inmovilla_ib( $settings );
+		if ( null === $server_ip ) {
+			$server_ip = self::get_inmovilla_server_ip();
+		}
+		$body  = 'param=' . $texto;
+		$body .= '&json=1'; // Request JSON response.
+		$body .= '&ia=' . rawurlencode( $ia );
+		$body .= '&ib=' . rawurlencode( $server_ip );
 
 		// Add domain to the request, matching the official Inmovilla client order.
 		$parsed_url = wp_parse_url( get_site_url() );
@@ -398,21 +408,39 @@ class API {
 	}
 
 	/**
-	 * Get a valid administrator override or use the calculated IP address.
+	 * Get a valid administrator override for IA.
 	 *
 	 * @param array  $settings Plugin settings.
 	 * @param string $key Setting key.
-	 * @param string $fallback_ip Calculated fallback IP address.
 	 * @return string IP address.
 	 */
-	private static function get_configured_inmovilla_ip( $settings, $key, $fallback_ip ) {
+	private static function get_configured_inmovilla_ip( $settings, $key ) {
 		$ip = isset( $settings[ $key ] ) ? $settings[ $key ] : '';
 
 		if ( is_string( $ip ) && self::is_public_ip( $ip ) ) {
 			return $ip;
 		}
 
-		return $fallback_ip;
+		return '';
+	}
+
+	/**
+	 * Get the IB override, including an explicitly empty override.
+	 *
+	 * @param array $settings Plugin settings.
+	 * @return string|null IP address or empty string for an explicit blank override; null for automatic mode.
+	 */
+	private static function get_configured_inmovilla_ib( $settings ) {
+		if ( ! isset( $settings['ib_override'] ) || 'yes' !== $settings['ib_override'] ) {
+			return null;
+		}
+
+		$ip = isset( $settings['ib'] ) ? $settings['ib'] : '';
+		if ( '' === $ip ) {
+			return '';
+		}
+
+		return self::is_public_ip( $ip ) ? $ip : null;
 	}
 
 	/**

--- a/includes/class-helper-api.php
+++ b/includes/class-helper-api.php
@@ -181,14 +181,12 @@ class API {
 		$texto = rawurlencode( $texto );
 
 		// Build POST body with IP tracking for API security.
-		// Inmovilla whitelists the server's IP, not the visitor triggering the
-		// request, so ia/ib always carry the server's own public IP — the same
-		// value regardless of whether this runs from a browser click or cron.
-		$server_ip = self::get_server_public_ip();
+		$ia        = self::get_configured_inmovilla_ip( $settings, 'ia', self::get_inmovilla_client_ip() );
+		$server_ip = self::get_configured_inmovilla_ip( $settings, 'ib', self::get_inmovilla_server_ip() );
 		$body      = 'param=' . $texto;
 		$body     .= '&json=1'; // Request JSON response.
-		$body     .= '&ia=' . $server_ip;
-		$body     .= '&ib=' . $server_ip;
+		$body     .= '&ia=' . rawurlencode( $ia );
+		$body     .= '&ib=' . rawurlencode( $server_ip );
 
 		// Add domain to the request, matching the official Inmovilla client order.
 		$parsed_url = wp_parse_url( get_site_url() );
@@ -354,6 +352,67 @@ class API {
 			'error_type' => 'ip_not_registered',
 			'mailto'     => $mailto,
 		);
+	}
+
+	/**
+	 * Get the IP address of the user making the current request.
+	 *
+	 * Studio and many managed hosts proxy requests through localhost, so prefer
+	 * the client IP headers supplied by that proxy before using REMOTE_ADDR.
+	 *
+	 * @return string IP address or empty string when unavailable.
+	 */
+	public static function get_inmovilla_client_ip() {
+		$header_keys = array(
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_REAL_IP',
+		);
+
+		foreach ( $header_keys as $header_key ) {
+			if ( empty( $_SERVER[ $header_key ] ) ) {
+				continue;
+			}
+
+			$ips = explode( ',', sanitize_text_field( wp_unslash( $_SERVER[ $header_key ] ) ) );
+			foreach ( $ips as $ip ) {
+				$ip = trim( $ip );
+				if ( self::is_public_ip( $ip ) ) {
+					return $ip;
+				}
+			}
+		}
+
+		$client_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+
+		return self::is_public_ip( $client_ip ) ? $client_ip : '';
+	}
+
+	/**
+	 * Get the default server IP sent as the Inmovilla IB parameter.
+	 *
+	 * @return string Public IP address or empty string on failure.
+	 */
+	public static function get_inmovilla_server_ip() {
+		return self::get_server_public_ip();
+	}
+
+	/**
+	 * Get a valid administrator override or use the calculated IP address.
+	 *
+	 * @param array  $settings Plugin settings.
+	 * @param string $key Setting key.
+	 * @param string $fallback_ip Calculated fallback IP address.
+	 * @return string IP address.
+	 */
+	private static function get_configured_inmovilla_ip( $settings, $key, $fallback_ip ) {
+		$ip = isset( $settings[ $key ] ) ? $settings[ $key ] : '';
+
+		if ( is_string( $ip ) && self::is_public_ip( $ip ) ) {
+			return $ip;
+		}
+
+		return $fallback_ip;
 	}
 
 	/**

--- a/includes/class-iip-admin.php
+++ b/includes/class-iip-admin.php
@@ -453,15 +453,6 @@ class Admin {
 			}
 		}
 
-		$ib = isset( $settings['ib'] ) ? $settings['ib'] : '';
-		if ( false === filter_var( $ib, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-			$server_ip = API::get_inmovilla_server_ip();
-			if ( false !== filter_var( $server_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-				$settings['ib'] = $server_ip;
-				$updated        = true;
-			}
-		}
-
 		if ( $updated ) {
 			update_option( 'ccrmre_settings', $settings );
 		}
@@ -725,7 +716,7 @@ class Admin {
 			'apipassword',
 			'numagencia',
 			'ia',
-			'ib',
+			'ib_override',
 			'post_type',
 			'post_type_slug',
 			'sold_action',
@@ -753,6 +744,11 @@ class Admin {
 			if ( isset( $input[ $field_value ] ) ) {
 				$sanitary_values[ $field_value ] = sanitize_text_field( $input[ $field_value ] );
 			}
+		}
+
+		$sanitary_values['ib_override'] = isset( $input['ib_override'] ) && 'yes' === $input['ib_override'] ? 'yes' : 'no';
+		if ( 'yes' === $sanitary_values['ib_override'] ) {
+			$sanitary_values['ib'] = isset( $input['ib'] ) ? sanitize_text_field( $input['ib'] ) : '';
 		}
 
 		foreach ( array( 'ia', 'ib' ) as $ip_field ) {
@@ -861,15 +857,16 @@ class Admin {
 	 * @return void
 	 */
 	public function inmovilla_ib_callback() {
-		$ib = isset( $this->settings['ib'] ) ? $this->settings['ib'] : '';
-		if ( false === filter_var( $ib, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-			$ib = API::get_inmovilla_server_ip();
-		}
+		$is_override = isset( $this->settings['ib_override'] ) && 'yes' === $this->settings['ib_override'];
+		$ib          = $is_override && isset( $this->settings['ib'] ) ? $this->settings['ib'] : API::get_inmovilla_server_ip();
 
 		printf(
-			'<input class="regular-text" type="text" name="ccrmre_settings[ib]" id="ccrmre_inmovilla_ib" value="%s"><br><small>%s</small>',
+			'<label><input type="checkbox" name="ccrmre_settings[ib_override]" id="ccrmre_inmovilla_ib_override" value="yes" %1$s> %2$s</label><br><input class="regular-text" type="text" name="ccrmre_settings[ib]" id="ccrmre_inmovilla_ib" value="%3$s" %4$s><br><small>%5$s</small>',
+			checked( $is_override, true, false ),
+			esc_html__( 'Override the calculated server IP', 'connect-crm-realstate' ),
 			esc_attr( $ib ),
-			esc_html__( 'Calculated from the public IP address of the server. You can override it if needed.', 'connect-crm-realstate' )
+			disabled( $is_override, false, false ),
+			esc_html__( 'Leave the override value empty to send IB empty, as required by some proxy configurations.', 'connect-crm-realstate' )
 		);
 	}
 

--- a/includes/class-iip-admin.php
+++ b/includes/class-iip-admin.php
@@ -590,7 +590,7 @@ class Admin {
 
 			add_settings_field(
 				'ccrmre_inmovilla_ia',
-				__( 'IA', 'connect-crm-realstate' ),
+				__( 'User IP (IA)', 'connect-crm-realstate' ),
 				array( $this, 'inmovilla_ia_callback' ),
 				'ccrmre_settings',
 				'ccrmre_admin_settings'
@@ -598,7 +598,7 @@ class Admin {
 
 			add_settings_field(
 				'ccrmre_inmovilla_ib',
-				__( 'IB', 'connect-crm-realstate' ),
+				__( 'Server IP (IB)', 'connect-crm-realstate' ),
 				array( $this, 'inmovilla_ib_callback' ),
 				'ccrmre_settings',
 				'ccrmre_admin_settings'

--- a/includes/class-iip-admin.php
+++ b/includes/class-iip-admin.php
@@ -45,6 +45,7 @@ class Admin {
 		add_action( 'admin_notices', array( $this, 'show_admin_notices' ) );
 		add_action( 'wp_ajax_ccrmre_auto_map_fields', array( $this, 'ajax_auto_map_fields' ) );
 		add_action( 'wp_ajax_ccrmre_import_enums', array( $this, 'ajax_import_enums' ) );
+		add_action( 'wp_ajax_ccrmre_store_inmovilla_client_ip', array( $this, 'ajax_store_inmovilla_client_ip' ) );
 	}
 
 	/**
@@ -58,6 +59,28 @@ class Admin {
 		}
 
 		$active_tab = ( isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'iip-import' );
+		$settings   = get_option( 'ccrmre_settings', array() );
+		$ia         = isset( $settings['ia'] ) ? $settings['ia'] : '';
+
+		// Studio and other local proxies do not always forward the browser IP to PHP.
+		if ( isset( $settings['type'] ) && 'inmovilla' === $settings['type'] && false === filter_var( $ia, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			wp_enqueue_script(
+				'ccrmre-client-ip',
+				plugin_dir_url( __FILE__ ) . 'assets/iip-client-ip.js',
+				array(),
+				CCRMRE_VERSION,
+				true
+			);
+			wp_localize_script(
+				'ccrmre-client-ip',
+				'ccrmreClientIp',
+				array(
+					'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+					'nonce'      => wp_create_nonce( 'ccrmre_store_inmovilla_client_ip_nonce' ),
+					'reloadPage' => 'iip-settings' === $active_tab,
+				)
+			);
+		}
 
 		if ( 'iip-merge' === $active_tab ) {
 			$merge_fields = get_option( 'ccrmre_merge_fields' );
@@ -302,6 +325,7 @@ class Admin {
 	 * @return void
 	 */
 	public function plugin_options_page() {
+		$this->ensure_inmovilla_ip_settings();
 		$this->settings        = get_option( 'ccrmre_settings' );
 		$this->settings_fields = get_option( 'ccrmre_merge_fields' );
 
@@ -402,6 +426,45 @@ class Admin {
 		do_action( 'ccrmre_admin_tab_content', $active_tab );
 
 		echo '</div>';
+	}
+
+	/**
+	 * Calculate missing Inmovilla APIWEB IP settings when visiting the plugin.
+	 *
+	 * IA is populated from the request when the proxy exposes a public client
+	 * IP. IA otherwise remains available for the browser-side lookup. IB is
+	 * always calculated from the server's public outbound IP.
+	 *
+	 * @return void
+	 */
+	private function ensure_inmovilla_ip_settings() {
+		$settings = get_option( 'ccrmre_settings', array() );
+		if ( ! is_array( $settings ) || ! isset( $settings['type'] ) || 'inmovilla' !== $settings['type'] ) {
+			return;
+		}
+
+		$updated = false;
+		$ia      = isset( $settings['ia'] ) ? $settings['ia'] : '';
+		if ( false === filter_var( $ia, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			$client_ip = API::get_inmovilla_client_ip();
+			if ( false !== filter_var( $client_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+				$settings['ia'] = $client_ip;
+				$updated        = true;
+			}
+		}
+
+		$ib = isset( $settings['ib'] ) ? $settings['ib'] : '';
+		if ( false === filter_var( $ib, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			$server_ip = API::get_inmovilla_server_ip();
+			if ( false !== filter_var( $server_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+				$settings['ib'] = $server_ip;
+				$updated        = true;
+			}
+		}
+
+		if ( $updated ) {
+			update_option( 'ccrmre_settings', $settings );
+		}
 	}
 
 	/**
@@ -521,6 +584,22 @@ class Admin {
 				'ccrmre_numagencia',
 				__( 'Agency Number', 'connect-crm-realstate' ),
 				array( $this, 'numagencia_callback' ),
+				'ccrmre_settings',
+				'ccrmre_admin_settings'
+			);
+
+			add_settings_field(
+				'ccrmre_inmovilla_ia',
+				__( 'IA', 'connect-crm-realstate' ),
+				array( $this, 'inmovilla_ia_callback' ),
+				'ccrmre_settings',
+				'ccrmre_admin_settings'
+			);
+
+			add_settings_field(
+				'ccrmre_inmovilla_ib',
+				__( 'IB', 'connect-crm-realstate' ),
+				array( $this, 'inmovilla_ib_callback' ),
 				'ccrmre_settings',
 				'ccrmre_admin_settings'
 			);
@@ -645,6 +724,8 @@ class Admin {
 			'type',
 			'apipassword',
 			'numagencia',
+			'ia',
+			'ib',
 			'post_type',
 			'post_type_slug',
 			'sold_action',
@@ -671,6 +752,25 @@ class Admin {
 		foreach ( $field_values as $field_value ) {
 			if ( isset( $input[ $field_value ] ) ) {
 				$sanitary_values[ $field_value ] = sanitize_text_field( $input[ $field_value ] );
+			}
+		}
+
+		foreach ( array( 'ia', 'ib' ) as $ip_field ) {
+			if ( empty( $sanitary_values[ $ip_field ] ) ) {
+				continue;
+			}
+
+			if ( false === filter_var( $sanitary_values[ $ip_field ], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+				$sanitary_values[ $ip_field ] = '';
+				add_settings_error(
+					'ccrmre_settings',
+					'invalid_' . $ip_field,
+					sprintf(
+						/* translators: %s: Inmovilla parameter name. */
+						__( '%s must be a public IP address.', 'connect-crm-realstate' ),
+						strtoupper( $ip_field )
+					)
+				);
 			}
 		}
 
@@ -734,6 +834,42 @@ class Admin {
 			'<input class="regular-text" type="text" name="ccrmre_settings[numagencia]" id="numagencia" value="%s"><br><small>%s</small>',
 			isset( $this->settings['numagencia'] ) ? esc_attr( $this->settings['numagencia'] ) : '',
 			esc_html__( 'API Username', 'connect-crm-realstate' )
+		);
+	}
+
+	/**
+	 * IA callback (Inmovilla APIWEB only).
+	 *
+	 * @return void
+	 */
+	public function inmovilla_ia_callback() {
+		$ia = isset( $this->settings['ia'] ) ? $this->settings['ia'] : '';
+		if ( false === filter_var( $ia, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			$ia = API::get_inmovilla_client_ip();
+		}
+
+		printf(
+			'<input class="regular-text" type="text" name="ccrmre_settings[ia]" id="ccrmre_inmovilla_ia" value="%s"><br><small>%s</small>',
+			esc_attr( $ia ),
+			esc_html__( 'Calculated from the IP address of the current user. You can override it if needed.', 'connect-crm-realstate' )
+		);
+	}
+
+	/**
+	 * IB callback (Inmovilla APIWEB only).
+	 *
+	 * @return void
+	 */
+	public function inmovilla_ib_callback() {
+		$ib = isset( $this->settings['ib'] ) ? $this->settings['ib'] : '';
+		if ( false === filter_var( $ib, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			$ib = API::get_inmovilla_server_ip();
+		}
+
+		printf(
+			'<input class="regular-text" type="text" name="ccrmre_settings[ib]" id="ccrmre_inmovilla_ib" value="%s"><br><small>%s</small>',
+			esc_attr( $ib ),
+			esc_html__( 'Calculated from the public IP address of the server. You can override it if needed.', 'connect-crm-realstate' )
 		);
 	}
 
@@ -1360,6 +1496,41 @@ class Admin {
 		}
 
 		wp_send_json_success( array( 'steps' => $steps ) );
+	}
+
+	/**
+	 * Store the public IP detected in the administrator's browser for APIWEB.
+	 *
+	 * @return void
+	 */
+	public function ajax_store_inmovilla_client_ip() {
+		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ccrmre_store_inmovilla_client_ip_nonce' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'connect-crm-realstate' ) ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'connect-crm-realstate' ) ) );
+		}
+
+		$ip = isset( $_POST['ip'] ) ? sanitize_text_field( wp_unslash( $_POST['ip'] ) ) : '';
+		if ( false === filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			wp_send_json_error( array( 'message' => __( 'A public IP address is required.', 'connect-crm-realstate' ) ) );
+		}
+
+		$settings = get_option( 'ccrmre_settings', array() );
+		if ( ! is_array( $settings ) || ! isset( $settings['type'] ) || 'inmovilla' !== $settings['type'] ) {
+			wp_send_json_error( array( 'message' => __( 'Inmovilla APIWEB is not configured.', 'connect-crm-realstate' ) ) );
+		}
+
+		$current_ip = isset( $settings['ia'] ) ? $settings['ia'] : '';
+		if ( false !== filter_var( $current_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			wp_send_json_success( array( 'updated' => false ) );
+		}
+
+		$settings['ia'] = $ip;
+		update_option( 'ccrmre_settings', $settings );
+
+		wp_send_json_success( array( 'updated' => true ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -59,7 +59,7 @@ Used to fetch property listings and details. The plugin sends your configured AP
 Used to fetch property data when you use the Inmovilla Procesos CRM type. The plugin sends your API credentials and request parameters only during import or sync. Inmovilla [terms](https://inmovilla.com/aviso-legal/) and [privacy policy](https://www.inmovilla.com/politica-de-privacidad/)
 
 **ipify (api.ipify.org)**
-Inmovilla APIWEB requires your server's public IP address to be whitelisted. If it can't be read from the server environment (e.g. behind certain proxies or containers), the plugin requests it from api.ipify.org, which returns only the IP address of the request — no other site or visitor data is sent. This call only happens when using the Inmovilla APIWEB CRM type and the server IP can't otherwise be determined. ipify [terms](https://www.ipify.org/) and [privacy policy](https://www.ipify.org/).
+Inmovilla APIWEB requires IP parameters. If the server's public IP can't be read from the server environment (e.g. behind certain proxies or containers), the plugin requests it from api.ipify.org. When the administrator's browser IP (IA) is unavailable, it requests that IP directly from the browser while visiting the plugin settings. ipify returns only the IP address of the request — no other site or visitor data is sent. These calls only happen when using the Inmovilla APIWEB CRM type and the relevant IP can't otherwise be determined. ipify [terms](https://www.ipify.org/) and [privacy policy](https://www.ipify.org/).
 
 == Installation ==
 
@@ -98,6 +98,7 @@ Yes, you can filter by postal code. Use wildcards like `18*` to include all prop
 == Changelog ==
 
 = 1.2.5 =
+* Added configurable IA and IB IP parameters for Inmovilla APIWEB connections. IA defaults to the current user's IP address and IB to the server's public IP address.
 * Fixed: automatic sync error due to IP address change.
 * Fix cron import not getting IP address for Inmovilla APIWEB, causing registration errors and failed imports.
 

--- a/tests/Unit/HelperApiTest.php
+++ b/tests/Unit/HelperApiTest.php
@@ -43,6 +43,13 @@ class HelperAPITest extends WP_UnitTestCase {
 	private $mock_apiweb_body = null;
 
 	/**
+	 * Body of the latest APIWEB request received by the HTTP mock.
+	 *
+	 * @var string
+	 */
+	private $mock_apiweb_request_body = '';
+
+	/**
 	 * Set up test environment.
 	 */
 	public function setUp(): void {
@@ -51,6 +58,7 @@ class HelperAPITest extends WP_UnitTestCase {
 		$this->mock_api_properties = null;
 		$this->mock_api_error      = false;
 		$this->mock_apiweb_body    = null;
+		$this->mock_apiweb_request_body = '';
 		$this->cleanup_properties();
 
 		// Avoid sleep() in execute_with_retry when mock returns error (test_propagates_api_http_error, etc.).
@@ -99,6 +107,8 @@ class HelperAPITest extends WP_UnitTestCase {
 	public function mock_http_request( $pre, $args, $url ) {
 		// Inmovilla APIWEB (apiweb.inmovilla.com): POST with param= encoded body; tipo is 5th field (index 4).
 		if ( false !== strpos( $url, 'apiweb.inmovilla.com' ) ) {
+			$this->mock_apiweb_request_body = isset( $args['body'] ) ? $args['body'] : '';
+
 			if ( $this->mock_api_error ) {
 				return array(
 					'body'     => '',
@@ -321,6 +331,45 @@ class HelperAPITest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'nodisponible', $first );
 		$this->assertArrayHasKey( 'fechaact', $first );
 		$this->assertArrayHasKey( 'keyprov', $first );
+	}
+
+	/**
+	 * Inmovilla APIWEB: saved IA and IB values override calculated defaults.
+	 */
+	public function test_inmovilla_api_uses_configured_ia_and_ib() {
+		update_option(
+			'ccrmre_settings',
+			array(
+				'type'        => 'inmovilla',
+				'numagencia'  => '6533',
+				'apipassword' => 'test',
+				'ia'          => '8.8.8.8',
+				'ib'          => '1.1.1.1',
+				'post_type'   => 'property',
+			)
+		);
+
+		$result = API::request_inmovilla( 'paginacion', 1, 10 );
+
+		$this->assertSame( 'ok', $result['status'] );
+		$this->assertStringContainsString( '&ia=8.8.8.8', $this->mock_apiweb_request_body );
+		$this->assertStringContainsString( '&ib=1.1.1.1', $this->mock_apiweb_request_body );
+	}
+
+	/**
+	 * Inmovilla APIWEB: proxy-provided client IP takes precedence over localhost.
+	 */
+	public function test_inmovilla_client_ip_uses_forwarded_header() {
+		$server = $_SERVER;
+
+		$_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '81.37.169.155, 127.0.0.1';
+
+		try {
+			$this->assertSame( '81.37.169.155', API::get_inmovilla_client_ip() );
+		} finally {
+			$_SERVER = $server;
+		}
 	}
 
 	/**
@@ -1305,4 +1354,3 @@ class HelperAPITest extends WP_UnitTestCase {
 		}
 	}
 }
-

--- a/tests/Unit/HelperApiTest.php
+++ b/tests/Unit/HelperApiTest.php
@@ -345,6 +345,7 @@ class HelperAPITest extends WP_UnitTestCase {
 				'apipassword' => 'test',
 				'ia'          => '8.8.8.8',
 				'ib'          => '1.1.1.1',
+				'ib_override' => 'yes',
 				'post_type'   => 'property',
 			)
 		);
@@ -354,6 +355,71 @@ class HelperAPITest extends WP_UnitTestCase {
 		$this->assertSame( 'ok', $result['status'] );
 		$this->assertStringContainsString( '&ia=8.8.8.8', $this->mock_apiweb_request_body );
 		$this->assertStringContainsString( '&ib=1.1.1.1', $this->mock_apiweb_request_body );
+	}
+
+	/**
+	 * Inmovilla APIWEB: an explicit blank IB override is sent as blank.
+	 */
+	public function test_inmovilla_api_allows_blank_ib_override() {
+		update_option(
+			'ccrmre_settings',
+			array(
+				'type'        => 'inmovilla',
+				'numagencia'  => '6533',
+				'apipassword' => 'test',
+				'ia'          => '8.8.8.8',
+				'ib'          => '',
+				'ib_override' => 'yes',
+				'post_type'   => 'property',
+			)
+		);
+
+		$result = API::request_inmovilla( 'paginacion', 1, 10 );
+
+		$this->assertSame( 'ok', $result['status'] );
+		$this->assertStringContainsString( '&ib=&elDominio=', $this->mock_apiweb_request_body );
+	}
+
+	/**
+	 * Inmovilla APIWEB: unattended requests use the server IP for IA.
+	 */
+	public function test_inmovilla_api_uses_server_ip_for_missing_ia() {
+		$server        = $_SERVER;
+		$cached_ip     = get_option( 'ccrmre_server_public_ip', false );
+		$cached_expiry = get_option( 'ccrmre_server_public_ip_expiry', false );
+
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		update_option( 'ccrmre_server_public_ip', '8.8.4.4' );
+		update_option( 'ccrmre_server_public_ip_expiry', time() + HOUR_IN_SECONDS );
+		update_option(
+			'ccrmre_settings',
+			array(
+				'type'        => 'inmovilla',
+				'numagencia'  => '6533',
+				'apipassword' => 'test',
+				'ib_override' => 'yes',
+				'ib'          => '',
+				'post_type'   => 'property',
+			)
+		);
+
+		try {
+			$result = API::request_inmovilla( 'paginacion', 1, 10 );
+			$this->assertSame( 'ok', $result['status'] );
+			$this->assertStringContainsString( '&ia=8.8.4.4', $this->mock_apiweb_request_body );
+		} finally {
+			$_SERVER = $server;
+			if ( false === $cached_ip ) {
+				delete_option( 'ccrmre_server_public_ip' );
+			} else {
+				update_option( 'ccrmre_server_public_ip', $cached_ip );
+			}
+			if ( false === $cached_expiry ) {
+				delete_option( 'ccrmre_server_public_ip_expiry' );
+			} else {
+				update_option( 'ccrmre_server_public_ip_expiry', $cached_expiry );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add editable IA and IB settings for Inmovilla APIWEB
- calculate and persist missing public client and server IPs
- send configured IP values in APIWEB requests and cover them with tests

## Verification
- composer lint
- composer phpstan
- vendor/bin/phpunit --filter=HelperAPITest