### PR TITLE
Fix sold property availability

### DIFF
--- a/includes/class-helper-sync.php
+++ b/includes/class-helper-sync.php
@@ -415,7 +415,13 @@ class SYNC {
 	 * @return bool
 	 */
 	public static function is_property_available( $property, $crm ) {
-		$available = false;
+		$available     = false;
+		$property_info = API::get_property_info( $property, $crm );
+
+		// Normalize CRM-specific availability fields before evaluating the listing.
+		if ( null !== $property_info['status'] ) {
+			$property['status'] = $property_info['status'];
+		}
 
 		if ( isset( $property['status'] ) ) {
 			$available = (bool) $property['status'];

--- a/tests/Data/inmovilla-apiweb-available-property.json
+++ b/tests/Data/inmovilla-apiweb-available-property.json
@@ -1,0 +1,16 @@
+{
+	"paginacion": [
+		{
+			"posicion": 1,
+			"elementos": 1,
+			"total": 1
+		},
+		{
+			"cod_ofer": 900000,
+			"ref": "ANON-AVAILABLE-001",
+			"nodisponible": 0,
+			"fechaact": "2026-01-15 10:30:00",
+			"keyprov": 99
+		}
+	]
+}

--- a/tests/Data/inmovilla-apiweb-sold-property.json
+++ b/tests/Data/inmovilla-apiweb-sold-property.json
@@ -1,0 +1,16 @@
+{
+	"paginacion": [
+		{
+			"posicion": 1,
+			"elementos": 1,
+			"total": 1
+		},
+		{
+			"cod_ofer": 900001,
+			"ref": "ANON-SOLD-001",
+			"nodisponible": 1,
+			"fechaact": "2026-01-15 10:30:00",
+			"keyprov": 99
+		}
+	]
+}

--- a/tests/Unit/SyncAvailabilityTest.php
+++ b/tests/Unit/SyncAvailabilityTest.php
@@ -16,15 +16,38 @@ use WP_UnitTestCase;
 class SyncAvailabilityTest extends WP_UnitTestCase {
 
 	/**
-	 * Inmovilla sold listings use nodisponible with inverse semantics.
+	 * APIWEB nodisponible values are normalized before the availability check.
+	 *
+	 * @dataProvider inmovilla_nodisponible_provider
+	 *
+	 * @param mixed $nodisponible APIWEB nodisponible value.
+	 * @param bool  $expected      Expected availability.
 	 */
-	public function test_inmovilla_unavailable_property_is_not_available() {
+	public function test_inmovilla_nodisponible_values( $nodisponible, $expected ) {
 		$property = array(
 			'cod_ofer'     => 123,
-			'nodisponible' => 1,
+			'nodisponible' => $nodisponible,
 		);
 
-		$this->assertFalse( SYNC::is_property_available( $property, 'inmovilla' ) );
+		$this->assertSame( $expected, SYNC::is_property_available( $property, 'inmovilla' ) );
+	}
+
+	/**
+	 * Provides normal, null, and unexpected APIWEB availability values.
+	 *
+	 * @return array
+	 */
+	public function inmovilla_nodisponible_provider() {
+		return array(
+			'available integer'     => array( 0, true ),
+			'sold integer'          => array( 1, false ),
+			'available boolean'     => array( false, true ),
+			'sold boolean'          => array( true, false ),
+			'available string'      => array( '0', true ),
+			'sold string'           => array( '1', false ),
+			'null defaults to open' => array( null, true ),
+			'unexpected value'      => array( 5, false ),
+		);
 	}
 
 	/**

--- a/tests/Unit/SyncAvailabilityTest.php
+++ b/tests/Unit/SyncAvailabilityTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Tests for Sync::is_property_available().
+ *
+ * @package ConnectCRM\RealState\Tests
+ */
+
+namespace Close\ConnectCRM\RealState\Tests\Unit;
+
+use Close\ConnectCRM\RealState\SYNC;
+use WP_UnitTestCase;
+
+/**
+ * Sync availability test case.
+ */
+class SyncAvailabilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Inmovilla sold listings use nodisponible with inverse semantics.
+	 */
+	public function test_inmovilla_unavailable_property_is_not_available() {
+		$property = array(
+			'cod_ofer'     => 123,
+			'nodisponible' => 1,
+		);
+
+		$this->assertFalse( SYNC::is_property_available( $property, 'inmovilla' ) );
+	}
+
+	/**
+	 * Inmovilla available listings remain available after normalization.
+	 */
+	public function test_inmovilla_available_property_is_available() {
+		$property = array(
+			'cod_ofer'     => 123,
+			'nodisponible' => 0,
+		);
+
+		$this->assertTrue( SYNC::is_property_available( $property, 'inmovilla' ) );
+	}
+}

--- a/tests/Unit/SyncAvailabilityTest.php
+++ b/tests/Unit/SyncAvailabilityTest.php
@@ -28,14 +28,28 @@ class SyncAvailabilityTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Inmovilla available listings remain available after normalization.
+	 * The anonymized APIWEB sold-property fixture is treated as unavailable.
 	 */
-	public function test_inmovilla_available_property_is_available() {
-		$property = array(
-			'cod_ofer'     => 123,
-			'nodisponible' => 0,
-		);
+	public function test_inmovilla_apiweb_sold_fixture_is_not_available() {
+		$path    = UNIT_TESTS_DATA_PLUGIN_DIR . 'inmovilla-apiweb-sold-property.json';
+		$content = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Test fixture.
+		$fixture  = json_decode( $content, true );
+		$property = isset( $fixture['paginacion'][1] ) ? $fixture['paginacion'][1] : array();
 
+		$this->assertSame( 'ANON-SOLD-001', $property['ref'] );
+		$this->assertFalse( SYNC::is_property_available( $property, 'inmovilla' ) );
+	}
+
+	/**
+	 * The anonymized APIWEB available-property fixture remains available.
+	 */
+	public function test_inmovilla_apiweb_available_fixture_is_available() {
+		$path     = UNIT_TESTS_DATA_PLUGIN_DIR . 'inmovilla-apiweb-available-property.json';
+		$content  = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Test fixture.
+		$fixture  = json_decode( $content, true );
+		$property = isset( $fixture['paginacion'][1] ) ? $fixture['paginacion'][1] : array();
+
+		$this->assertSame( 'ANON-AVAILABLE-001', $property['ref'] );
 		$this->assertTrue( SYNC::is_property_available( $property, 'inmovilla' ) );
 	}
 }


### PR DESCRIPTION
## Summary
- Normalize CRM availability before evaluating a property listing.
- Correctly interpret Inmovilla's inverted nodisponible field.
- Cover available and sold Inmovilla listings with unit tests.

## Validation
- phpcs --standard=.phpcs.xml.dist
- phpstan analyse --memory-limit=2048M -c phpstan.neon.dist

Related to closemarketing/connect-crm-realstate-pro#46.